### PR TITLE
Add monthly costs chart generation

### DIFF
--- a/src/VMTS.API/Controllers/DashboardController.cs
+++ b/src/VMTS.API/Controllers/DashboardController.cs
@@ -77,8 +77,15 @@ public class DashboardController : BaseApiController
     [HttpGet("priority-chart")]
     public async Task<IActionResult> GetPriorityChart()
     {
-        var base64Chart = await _faultReportService.GetPriorityChartAsync();
+        var chartDto = await _faultReportService.GetPriorityChartAsync();
 
-        return Ok(new { chart = base64Chart });
+        return File(chartDto.ChartBase64, "image/jpeg", "priority-chart.jpg");
+    }
+
+    [HttpGet("time-series-costs-chart")]
+    public async Task<IActionResult> GetTimeSeriesCostsChart()
+    {
+        var chartDto = await _dashboardServices.GetTimeSeriesCostChartAsync();
+        return File(chartDto.ChartBytes, "image/jpeg", "monthly-costs-chart.jpg");
     }
 }

--- a/src/VMTS.Core/Interfaces/Services/IAiClient.cs
+++ b/src/VMTS.Core/Interfaces/Services/IAiClient.cs
@@ -4,5 +4,7 @@ namespace VMTS.Core.Interfaces.Services;
 
 public interface IAiClient
 {
-    Task<string> SendPrioritiesAndGetChartAsync(ChartDto chartDto);
+    Task<byte[]> SendPrioritiesAndGetChartAsync(ChartRequestDto chartDto);
+
+    Task<CostChartDto> SendMonthlyCostsAndGetChartAsync(MonthlyCostsChartDto dto);
 }

--- a/src/VMTS.Core/Interfaces/Services/IDashboardServices.cs
+++ b/src/VMTS.Core/Interfaces/Services/IDashboardServices.cs
@@ -1,3 +1,5 @@
+using VMTS.Core.Non_Entities_Class;
+
 namespace VMTS.Core.Interfaces.Services;
 
 public interface IDashboardServices
@@ -17,4 +19,5 @@ public interface IDashboardServices
     Task<int> GetVehicleUnderMaintenanceCount();
 
     Task<int> GetVehicleAvailableCount();
+    Task<CostChartDto> GetTimeSeriesCostChartAsync();
 }

--- a/src/VMTS.Core/Non-Entities Class/ChartDto.cs
+++ b/src/VMTS.Core/Non-Entities Class/ChartDto.cs
@@ -3,5 +3,5 @@ namespace VMTS.Core.Non_Entities_Class;
 public class ChartDto
 {
     public string[]? Priority { get; set; }
-    public string? ChartBase64 { get; set; } // 🔥 new property
+    public byte[]? ChartBase64 { get; set; }
 }

--- a/src/VMTS.Core/Non-Entities Class/ChartRequestDto.cs
+++ b/src/VMTS.Core/Non-Entities Class/ChartRequestDto.cs
@@ -1,0 +1,6 @@
+namespace VMTS.Core.Non_Entities_Class;
+
+public class ChartRequestDto
+{
+    public string[] Predictions { get; set; } = Array.Empty<string>();
+}

--- a/src/VMTS.Core/Non-Entities Class/CostChartDto.cs
+++ b/src/VMTS.Core/Non-Entities Class/CostChartDto.cs
@@ -1,0 +1,6 @@
+namespace VMTS.Core.Non_Entities_Class;
+
+public class CostChartDto
+{
+    public byte[]? ChartBytes { get; set; }
+}

--- a/src/VMTS.Core/Non-Entities Class/MonthlyCostsChartDto.cs
+++ b/src/VMTS.Core/Non-Entities Class/MonthlyCostsChartDto.cs
@@ -1,0 +1,15 @@
+using System.Text.Json.Serialization;
+
+namespace VMTS.Core.Non_Entities_Class;
+
+public class MonthlyCostsChartDto
+{
+    [JsonPropertyName("months")]
+    public string[] Months { get; set; } = default!;
+
+    [JsonPropertyName("fuel_costs")]
+    public decimal[] FuelCosts { get; set; } = default!;
+
+    [JsonPropertyName("maintenance_costs")]
+    public decimal[] MaintenanceCosts { get; set; } = default!;
+}

--- a/src/VMTS.Service/Services/AiClient.cs
+++ b/src/VMTS.Service/Services/AiClient.cs
@@ -17,18 +17,32 @@ public class AiClient : IAiClient
         _unitOfWork = unitOfWork;
     }
 
-    public async Task<string> SendPrioritiesAndGetChartAsync(ChartDto chartDto)
+    public async Task<byte[]> SendPrioritiesAndGetChartAsync(ChartRequestDto chartDto)
+    {
+        var endPoint = (await _unitOfWork.GetRepo<AiEndpointConfig>().GetAllAsync()).FirstOrDefault(
+            aic => aic.Name == "FaultPriviledge"
+        );
+
+        var response = await _httpClient.PostAsJsonAsync($"{endPoint.Url}/urgency_chart", chartDto);
+
+        var errorContent = await response.Content.ReadAsStringAsync();
+
+        if (!response.IsSuccessStatusCode)
+            throw new Exception($"AI error: {response.StatusCode}, body: {errorContent}");
+
+        return await response.Content.ReadAsByteArrayAsync(); // base64 image
+    }
+
+    public async Task<CostChartDto> SendMonthlyCostsAndGetChartAsync(MonthlyCostsChartDto dto)
     {
         var endPoint = (await _unitOfWork.GetRepo<AiEndpointConfig>().GetAllAsync())
-            .Where(aic => aic.Name == "FaultPriviledge")
-            .FirstOrDefault();
-        var response = await _httpClient.PostAsJsonAsync($"{endPoint.Url}/urgency_chart", chartDto);
-        if (!response.IsSuccessStatusCode)
-        {
-            var errorContent = await response.Content.ReadAsStringAsync();
-            response.EnsureSuccessStatusCode();
-        }
+            .FirstOrDefault(aic => aic.Name == "FaultPriviledge");
 
-        return await response.Content.ReadAsStringAsync();
+        var response = await _httpClient.PostAsJsonAsync($"{endPoint.Url}/costs_chart", dto);
+        response.EnsureSuccessStatusCode();
+
+        var imageBytes = await response.Content.ReadAsByteArrayAsync();
+
+        return new CostChartDto { ChartBytes = imageBytes };
     }
 }

--- a/src/VMTS.Service/Services/FaultReportService.cs
+++ b/src/VMTS.Service/Services/FaultReportService.cs
@@ -316,13 +316,14 @@ public class FaultReportService : IFaultReportService
         var priorityList = faultReports
             .Where(fr => !string.IsNullOrWhiteSpace(fr.Priority))
             .Select(fr => fr.Priority.Trim())
-            .ToList();
+            .ToArray();
 
-        var result = new ChartDto { Priority = priorityList.ToArray() };
+        var chartRequest = new ChartRequestDto { Predictions = priorityList };
 
-        var chartImageBase64 = await _aiClient.SendPrioritiesAndGetChartAsync(result);
+        var chartBase64 = await _aiClient.SendPrioritiesAndGetChartAsync(chartRequest);
 
-        return new ChartDto { Priority = priorityList.ToArray(), ChartBase64 = chartImageBase64 };
+        // Return ChartDto with both Priority list and base64 chart image
+        return new ChartDto { Priority = priorityList, ChartBase64 = chartBase64 };
     }
 
     #endregion


### PR DESCRIPTION
- Introduce `GetTimeSeriesCostChartAsync` in `DashboardServices` to compute monthly cost charts.
- Add `MonthlyCostsChartDto` for structuring chart requests and `CostChartDto` for responses.
- Modify `IAiClient` interface and `AiClient` to support new AI endpoint for cost charts.
- Update `DashboardController` with `/time-series-costs-chart` endpoint to serve monthly cost charts.
- Refactor priority chart logic to improve consistency and type handling.